### PR TITLE
Fix connection, retries on close.

### DIFF
--- a/display.js
+++ b/display.js
@@ -227,6 +227,7 @@ class SumoDisplay {
     close() {
         console.log(`Closing room "${this.roomKey}".`);
 
+        this.retry = 0
         this.removeAllPlayers()
         this.detachListener()
         this.detachAuthStateListener()

--- a/host-logic.js
+++ b/host-logic.js
@@ -71,8 +71,6 @@ display.onRoomCreatedFail = roomKey => {
     display.start(generateRoomId());
 };
 
-display.start(generateRoomId());
-
 
 function generateRoomId() {
     // Temp fix method to auto-generate roomIDs, until we implement a firebase function


### PR DESCRIPTION
# Fix issue 1 
Original implementation starts rtc connection immediately as soon as the page is loaded, which generate a new room. Once Unity loaded and player selected a game, the unity send a "restartRoom" packet and trigger regenerate room again.

# Fix issue 2
Once the room is closed and restarted, the retry value does not reset. After it hits the limit 5 the code will refuse to reinitialize a new room. Unity will stuck in "Setting up room". As consequences of issue 1 above, this will trigger after 2 games after returning to lobby.